### PR TITLE
Add basic rspec tests

### DIFF
--- a/spec/classes/uchiwa_spec.rb
+++ b/spec/classes/uchiwa_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'uchiwa', :type => :class do
+  context 'on RedHat OS', :compile do
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+      }
+    end
+
+    context 'with default params' do
+      it do
+        should contain_package('uchiwa')
+      end
+    end
+  end
+
+  context 'on Debian OS', :compile do
+    let :facts do
+      {
+        :osfamily  => 'Debian',
+        :lsbdistid => 'Debian',
+      }
+    end
+
+    context 'with default params' do
+      it do
+        should contain_package('uchiwa')
+      end
+    end
+  end
+
+  context 'on unsupported OS' do
+    let :facts do
+      {
+        :osfamily  => 'Unsupported',
+      }
+    end
+
+    context 'with default params' do
+      it do
+        expect {
+          should compile.with_all_deps
+        }.to raise_error(Puppet::Error, /not supported/)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+shared_examples :compile, :compile => true do
+  it { should compile.with_all_deps }
+end


### PR DESCRIPTION
`bundle exec rake spec` was failing as there were no `spec/{classes,defines,…}/*.rb` files so it was finding the tests in the apt modules fixtures directory instead.

Add basic tests so they now run and pass.
