### PR TITLE
Update apt.pp - Avoid Source conflict with sensu

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -22,15 +22,17 @@ class uchiwa::repo::apt {
         $url = 'http://repos.sensuapp.org/apt'
       }
 
-      apt::source { 'sensu':
-        ensure      => $ensure,
-        location    => $url,
-        release     => 'sensu',
-        repos       => $uchiwa::repo,
-        include_src => false,
-        key         => $uchiwa::repo_key_id,
-        key_source  => $uchiwa::repo_key_source,
-        before      => Package['uchiwa'],
+      if !defined(Apt::Source['sensu']) {
+        apt::source { 'sensu':
+          ensure      => $ensure,
+          location    => $url,
+          release     => 'sensu',
+          repos       => $uchiwa::repo,
+          include_src => false,
+          key         => $uchiwa::repo_key_id,
+          key_source  => $uchiwa::repo_key_source,
+          before      => Package['uchiwa'],
+        }
       }
 
     } else {


### PR DESCRIPTION
Source conflict with sensu puppet module. - Also requested in the sensu module [#231](https://github.com/sensu/sensu-puppet/pull/231)

```
Error: Duplicate declaration: Apt::Source[sensu] is already declared in file /tmp/vagrant-puppet-3/modules-0/uchiwa/manifests/repo/apt.pp:34; cannot redeclare at /tmp/vagrant-puppet-3/modules-0/sensu/manifests/repo/apt.pp:35
```
