### PR TITLE
use anchor pattern to fix containment of uchiwa class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,8 +125,9 @@ class uchiwa (
   validate_string($stats)
   validate_string($refresh)
 
+  anchor { 'uchiwa::begin': } ->
   class { 'uchiwa::install': } ->
   class { 'uchiwa::config': } ~>
   class { 'uchiwa::service': } ->
-  Class['uchiwa']
+  anchor { 'uchiwa::end': }
 }


### PR DESCRIPTION
Basically, I could not create a correct order structure from the outside, like:

``` puppet
class { 'sensu':
  manage_repo => true
}

class { 'uchiwa':
  manage_repo => false,
  require => Class['sensu']
}
```

would still lead to having the uchiwa::install class being executed before the sensu class could add the right repository. With the anchors I added it should be fixed.
