### PR TITLE
remove unnecessary str2bool in install.pp since input is already validated

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@ class uchiwa::install {
   case $::osfamily {
     'Debian': {
       class { 'uchiwa::repo::apt': }
-      if str2bool($uchiwa::install_repo) {
+      if ($uchiwa::install_repo) {
         $repo_require = Apt::Source['sensu']
       } else {
         $repo_require = undef
@@ -13,7 +13,7 @@ class uchiwa::install {
 
     'RedHat': {
       class { 'uchiwa::repo::yum': }
-      if str2bool($uchiwa::install_repo) {
+      if ($uchiwa::install_repo) {
         $repo_require = Yumrepo['sensu']
       } else {
         $repo_require = undef


### PR DESCRIPTION
Because uchiwa/manifests/init.pp already validates input, the str2bool is not needed and in fact breaks any input if trying to not install the sensu repo (which may have already been done by other modules).

uchiwa/manifests/init.pp
111: validate_bool($install_repo)
This will reject a string and only pass a boolean.
On my setup (puppetlabs-stdlib (v3.2.0), without the str2bool throws an error.

Example runs:

Before:
Setting a bool: str2bool() throws and error
class { 'uchiwa':
install_repo => false,
require => [ Class['sensu'], ],
}

Error: str2bool(): Requires either string to work with at /etc/puppet/modules/uchiwa/manifests/install.pp:16

Setting a string: caught by validate_bool

class { 'uchiwa':
install_repo => 'false',
require => [ Class['sensu'], ],
}

Error: "false" is not a boolean. It looks to be a String at /etc/puppet/modules/uchiwa/manifests/init.pp:111

After the change:
Input is always validated by str2bool() and only passes a bool.
Forces the calling manifest to use bool in install repo call.

class { 'uchiwa':
install_repo => false,
require => [ Class['sensu'], ],
}
