### PR TITLE
Fix puppet-uchiwa beaker tests

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -7,6 +7,7 @@ describe 'sensu class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily
       it 'should work with no errors' do
         pp = <<-EOS
         class { 'rabbitmq':
+          package_ensure    => installed,
           ssl               => false,
           delete_guest_user => true,
         }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,10 +29,21 @@ RSpec.configure do |c|
         # RubyGems missing on some Vagrant boxes
         # Otherwise you'lll get a load of 'Provider gem is not functional on this host'
         shell('apt-get install rubygems -y')
+        # TODO: puppetlabs-rabbitmq 4.1 doesn't support rabbitmq 3.4.0.
+        #       Remove the following two lines after a new puppetlabs-rabbitmq release
+        #       that contains PR #250
+        shell('apt-get install erlang-nox -y')
+        shell('wget http://www.rabbitmq.com/releases/rabbitmq-server/v3.3.5/rabbitmq-server_3.3.5-1_all.deb && sudo dpkg -i rabbitmq-server_3.3.5-1_all.deb')
       end
       if fact('osfamily') == 'RedHat'
         # RedHat needs EPEL for RabbitMQ and Redis
         shell('wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm && sudo rpm -Uvh epel-release-6*.rpm')
+        # TODO: puppetlabs-rabbitmq 4.1 doesn't support rabbitmq 3.4.0.
+        #       Remove the following three lines after a new puppetlabs-rabbitmq release
+        #       that contains PR #250
+        shell('sed -i \'s/\(mirrorlist=http\)s/\1/\' /etc/yum.repos.d/epel.repo')
+        shell('yum install -y erlang')
+        shell('rpm -Uvh http://www.rabbitmq.com/releases/rabbitmq-server/v3.3.5/rabbitmq-server-3.3.5-1.noarch.rpm')
       end
       shell('/bin/touch /etc/puppet/hiera.yaml')
       shell('puppet module install puppetlabs-stdlib --version 3.2.0', { :acceptable_exit_codes => [0] })


### PR DESCRIPTION
We are currently unable to run the puppet-uchiwa beaker tests for two reasons:
1. The latest version of puppetlabs/apt (1.7.0) is installed with puppetlabs/rabbitmq. However, later in the script, we attempt to install version 1.6.0. This operation generates an error.
   
   The solution is to install puppetlabs/apt version 1.6.0 before puppetlabs/rabbitmq, so we can install the desired version of puppetlabs/apt and satisfy the puppetlabs/rabbitmq's dependency.
2. The latest puppetlabs/rabbitmq module (v 3.4.0) is incompatible with the latest rabbitmq (v 4.1). There is currently a [PR open](https://github.com/puppetlabs/puppetlabs-rabbitmq/pull/250) in order to fix this.
   
   The solution is to install rabbitmq 3.3.5, which is compatible with the latest rabbitmq puppet module. Puppet won't install rabbitmq during its run. This needs cleaning up as soon as puppetlabs merges the PR and releases a compatible module.
