### PR TITLE
Remove the stats param from the puppet module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,11 +77,6 @@
 #    Default: ''
 #    The password of the Uchiwa dashboard. Leave empty for none.
 #
-#  [*stats*]
-#    String
-#    Default: 10
-#    Determines the retention, in minutes, of graphics data
-#
 #  [*refresh*]
 #    String
 #    Default: 5
@@ -103,7 +98,6 @@ class uchiwa (
   $port            = $uchiwa::params::port,
   $user            = $uchiwa::params::user,
   $pass            = $uchiwa::params::pass,
-  $stats           = $uchiwa::params::stats,
   $refresh         = $uchiwa::params::refresh
 ) inherits uchiwa::params {
 
@@ -122,7 +116,6 @@ class uchiwa (
   validate_string($port)
   validate_string($user)
   validate_string($pass)
-  validate_string($stats)
   validate_string($refresh)
 
   anchor { 'uchiwa::begin': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,5 @@ class uchiwa::params {
   $port            =     3000
   $user            =     ''
   $pass            =     ''
-  $stats           =     10
   $refresh         =     5
-
 }

--- a/templates/etc/sensu/uchiwa.json.erb
+++ b/templates/etc/sensu/uchiwa.json.erb
@@ -12,7 +12,6 @@
     "port": <%= @data['port'] %>,
     "user": "<%= @data['user'] %>",
     "pass": "<%= @data['pass'] %>",
-    "stats": <%= @data['stats'] %>,
     "refresh": <%= @data['refresh'] %>
   }
 }


### PR DESCRIPTION
The stats param has been removed in uchiwa 0.3.0.

Please see [this commit](https://github.com/sensu/uchiwa/commit/71880ca3ed415af3c03d618620830d13e4c6f99e#diff-04c6e90faac2675aa89e2176d2eec7d8L84)
