### PR TITLE
The refresh param now takes seconds rather than ms

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,8 +84,8 @@
 #
 #  [*refresh*]
 #    String
-#    Default: 10000
-#    Determines the interval to pull the Sensu API, in milliseconds
+#    Default: 5
+#    Determines the interval to pull the Sensu API, in seconds
 #
 #
 class uchiwa (

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,6 @@ class uchiwa::params {
   $user            =     ''
   $pass            =     ''
   $stats           =     10
-  $refresh         =     10000
+  $refresh         =     5
 
 }


### PR DESCRIPTION
Updated the default value of the refresh param, which is now specified in seconds rather than milliseconds.

Please see [this commit](https://github.com/sensu/uchiwa/commit/71880ca3ed415af3c03d618620830d13e4c6f99e#diff-04c6e90faac2675aa89e2176d2eec7d8R65)
