### PR TITLE
Ensure uchiwa.json is not world-readable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,5 +7,8 @@ class uchiwa::config inherits uchiwa {
   file { '/etc/sensu/uchiwa.json':
     ensure  => file,
     content => template('uchiwa/etc/sensu/uchiwa.json.erb'),
+    owner   => uchiwa,
+    group   => uchiwa,
+    mode    => '0440',
   }
 }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -63,6 +63,12 @@ describe 'sensu class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily
         end
       end
 
+      describe file('/etc/sensu/uchiwa.json') do
+        it { should be_owned_by 'uchiwa' }
+        it { should be_grouped_into 'uchiwa' }
+        it { should be_mode 440 }
+      end
+
       it 'rerun puppet with default params' do
         
         pp = <<-EOS

--- a/spec/classes/uchiwa_spec.rb
+++ b/spec/classes/uchiwa_spec.rb
@@ -14,6 +14,9 @@ describe 'uchiwa' do
   context 'config file' do
     it { should contain_file('/etc/sensu/uchiwa.json').with_ensure('file') }
     it { should contain_file('/etc/sensu/uchiwa.json').with_content(/"host": "127.0.0.1"/) }
+    it { should contain_file('/etc/sensu/uchiwa.json').with_owner('uchiwa') }
+    it { should contain_file('/etc/sensu/uchiwa.json').with_group('uchiwa') }
+    it { should contain_file('/etc/sensu/uchiwa.json').with_mode('0440') }
   end
 
   context 'package' do


### PR DESCRIPTION
This file contains passwords and should be readable only to the
uchiwa service.

2 existing acceptance tests are failing for me -- the ones which compare JSON content -- but they also fail on the master branch, so they shouldn't be a blocker.