### PR TITLE
Notify uchiwa service when package changes

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,6 +41,7 @@ class uchiwa::install {
   package { $uchiwa::package_name:
     ensure  => $uchiwa::version,
     require => $repo_require,
+    notify  => Service['uchiwa'],
   }
 
 }

--- a/spec/classes/uchiwa_spec.rb
+++ b/spec/classes/uchiwa_spec.rb
@@ -33,7 +33,7 @@ describe 'uchiwa' do
 
       it { should contain_package('uchiwa').with(
         :ensure => '0.1.5'
-      ) }
+      ).that_notifies('Service[uchiwa]') }
     end
 
     context 'repos' do


### PR DESCRIPTION
By default the package is set to ensure latest - we were running with this,
which caused our preview environment to update. We fixed to the version running
in production - https://github.com/alphagov/pp-puppet/pull/735 but although the
package was downgraded, the service did not restart, hence adding the notify.
We had to downgrade because we hit a bug similar to
https://github.com/sensu/uchiwa/issues/272