### PR TITLE
Fix warning when installing sensu apt repository

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class uchiwa::params {
   $install_repo    = true
   $repo            = 'main'
   $repo_source     = undef
-  $repo_key_id     = '7580C77F'
+  $repo_key_id     = '8911D8FF37778F24B4E726A218609E3D7580C77F'
   $repo_key_source = 'http://repos.sensuapp.org/apt/pubkey.gpg'
   $manage_services = true
   $manage_user     = true

--- a/spec/classes/uchiwa_spec.rb
+++ b/spec/classes/uchiwa_spec.rb
@@ -57,7 +57,7 @@ describe 'uchiwa' do
               :release     => 'sensu',
               :repos       => 'main',
               :include_src => false,
-              :key         => '7580C77F',
+              :key         => '8911D8FF37778F24B4E726A218609E3D7580C77F',
               :key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg',
               :before      => 'Package[uchiwa]'
             ) }


### PR DESCRIPTION
New versions of puppetlabs/apt module show a warning if the repo_key_id hasn't the 40 digits.