### PR TITLE
Properly type port number

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,7 @@
 #    What IP should we bind to?
 #
 #  [*port*]
-#    String
+#    Integer
 #    Default: 3000
 #    What port should we run on?
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,7 @@ class uchiwa::params {
                           }]
 
   $host            =     '0.0.0.0'
-  $port            =     '3000'
+  $port            =     3000
   $user            =     ''
   $pass            =     ''
   $refresh         =     '5'


### PR DESCRIPTION
This PR will properly type the port number.  This solves issues encountered when using the future parser.