### PR TITLE
Try to cleanup doc and un-nest api definitions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,15 +21,18 @@ Versions greater than 0.3.0 are incompatible with previous versions of the Yelp-
 
 See `Modulefile` for details.
 
-## Basic example
+## Examples
 
-### Sensu server
+### Simple Setup
 
-    node 'uchiwa-server.foo.com' {
-      include ::uchiwa
-    }
+By default the puppet module will connect to a single Sensu API endpoint on
+localhost:
 
-## Advanced example using multiple APIs
+```puppet
+node 'uchiwa-server.foo.com' {
+  include ::uchiwa
+}
+```
 
 API definitions will default to the following values:
 
@@ -43,28 +46,48 @@ API definitions will default to the following values:
     path     => ''
     timeout  => 5
 
-This is an example of a 2 API setup:
+### Simple Server Without the Repo
 
-    node 'uchiwa-server.foo.com' {
+The module itself sets up the Sensu repo in order to download Uchiwa. Often this
+is also done by the Sensu puppet module too. To get around this duplication you
+can ask the Uchiwa module not to manage the repo:
 
-      $uchiwa_api_config = [{
-                              host  => '10.56.5.8',
-                            },
-                            {
-                              host      => '10.16.1.25',
-                              ssl       => true,
-                              insecure  => true,
-                              port      => 7654,
-                              user      => 'sensu',
-                              pass      => 'saBEnX8PQoyz2LG',
-                              path      => '/sensu',
-                              timeout   => 5
-                            }]
+```puppet
+class { '::uchiwa':
+  manage_repo => false,
+}
+```
 
-      class { 'uchiwa':
-        sensu_api_endpoints => $uchiwa_api_config,
-      }
+### Advanced Example Using Multiple APIs
+
+This is an example of how to setup Uchiwa connecting
+to two different API endpoints. In this example there is
+one endpoint using mostly default parameters, and then
+a second endpoint using all the possible options:
+
+```puppet
+node 'uchiwa-server.foo.com' {
+
+  $uchiwa_api_config = [
+    {
+      host  => '10.56.5.8',
+    },
+    {
+      host      => '10.16.1.25',
+      ssl       => true,
+      insecure  => true,
+      port      => 7654,
+      user      => 'sensu',
+      pass      => 'saBEnX8PQoyz2LG',
+      path      => '/sensu',
+      timeout   => 5
     }
+  ]
+  class { 'uchiwa':
+    sensu_api_endpoints => $uchiwa_api_config,
+  }
+}
+```
 
 ## License
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,18 +27,19 @@ class uchiwa::params {
   $manage_services = true
   $manage_user     = true
 
-  $sensu_api_endpoints  = [{
-                            name     =>  'sensu',
-                            host     => '127.0.0.1',
-                            ssl      =>  false,
-                            insecure =>  false,
-                            port     =>  4567,
-                            user     =>  'sensu',
-                            pass     =>  'sensu',
-                            path     =>  '',
-                            timeout  =>  5,
-                          }]
-
+  $sensu_api_endpoints  = [
+    {
+      name     =>  'sensu',
+      host     => '127.0.0.1',
+      ssl      =>  false,
+      insecure =>  false,
+      port     =>  4567,
+      user     =>  'sensu',
+      pass     =>  'sensu',
+      path     =>  '',
+      timeout  =>  5,
+    }
+  ]
   $host            =     '0.0.0.0'
   $port            =     3000
   $user            =     ''


### PR DESCRIPTION
The `manage_repo` thing seemed to be a faq, enough to justify having it on the front page I think.