### PR TITLE
Changed example code from manage_repo to install_repo

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,7 +54,7 @@ can ask the Uchiwa module not to manage the repo:
 
 ```puppet
 class { '::uchiwa':
-  manage_repo => false,
+  install_repo => false,
 }
 ```
 


### PR DESCRIPTION
The example in the README suggested using manage_repo in order to disable management of repo by uchiwa, but according to the actual code (and my experience), the variable should be install_repo. 