### PR TITLE
Update apt::source to use puppetlabs-apt 2.0.0+

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -23,14 +23,19 @@ class uchiwa::repo::apt {
       }
 
       apt::source { 'sensu':
-        ensure      => $ensure,
-        location    => $url,
-        release     => 'sensu',
-        repos       => $uchiwa::repo,
-        include_src => false,
-        key         => $uchiwa::repo_key_id,
-        key_source  => $uchiwa::repo_key_source,
-        before      => Package['uchiwa'],
+        ensure   => $ensure,
+        before   => Package['uchiwa'],
+        include  => {
+          'src' => false,
+          'deb' => true,
+        },
+        key      => {
+          'id'     => $uchiwa::repo_key_id,
+          'source' => $uchiwa::repo_key_source,
+        },
+        location => $url,
+        release  => 'sensu',
+        repos    => $uchiwa::repo,
       }
 
     } else {

--- a/metadata.json
+++ b/metadata.json
@@ -65,7 +65,7 @@
   "issues_url": "https://github.com/yelp/puppet-uchiwa/issues",
   "description": "Puppet module for installing Uchiwa",
   "dependencies": [
-    {"name":"puppetlabs/apt","version_requirement": ">=1.4.0 <2.0.0"},
+    {"name":"puppetlabs/apt","version_requirement": ">=2.0.0 <3.0.0"},
     {"name":"puppetlabs/stdlib"}
   ]
 }

--- a/spec/classes/uchiwa_spec.rb
+++ b/spec/classes/uchiwa_spec.rb
@@ -48,18 +48,17 @@ describe 'uchiwa' do
         }
 
         context 'with puppet-apt installed' do
-          let(:pre_condition) { [ 'define apt::source ($ensure, $location, $release, $repos, $include_src, $key, $key_source) {}' ] }
+          let(:pre_condition) { [ 'define apt::source ($ensure, $location, $release, $repos, $include, $key) {}' ] }
 
           context 'default' do
             it { should contain_apt__source('sensu').with(
-              :ensure      => 'present',
-              :location    => 'http://repos.sensuapp.org/apt',
-              :release     => 'sensu',
-              :repos       => 'main',
-              :include_src => false,
-              :key         => '8911D8FF37778F24B4E726A218609E3D7580C77F',
-              :key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg',
-              :before      => 'Package[uchiwa]'
+              :ensure   => 'present',
+              :location => 'http://repos.sensuapp.org/apt',
+              :release  => 'sensu',
+              :repos    => 'main',
+              :include  => { 'src' => false, 'deb' => true },
+              :key      => { 'id' => '8911D8FF37778F24B4E726A218609E3D7580C77F', 'source' => 'http://repos.sensuapp.org/apt/pubkey.gpg' },
+              :before   => 'Package[uchiwa]'
             ) }
           end
 


### PR DESCRIPTION
Since the newest [sensu-puppet](https://github.com/sensu/sensu-puppet) module requires puppetlabs-apt >=2.0.0 it makes sense to me to migrate this to be puppetlabs-apt >=2.0.0 as well.

This is basically the same changes that @bleuchtang made in #45 except there are no merge conflicts as I pulled the latest master and made the changes there.
Closes #45