### PR TITLE
Adding option to not install the uchiwa package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,11 @@
 #    Default: http://repos.sensuapp.org/apt/pubkey.gpg
 #    GPG key for the repo we're installing
 #
+#  [*install_package*]
+#    Boolean
+#    Default: true
+#    Should we install the package from the repo?
+#
 #  [*manage_services*]
 #    Boolean
 #    Default: true
@@ -104,6 +109,7 @@ class uchiwa (
   $repo_source          = $uchiwa::params::repo_source,
   $repo_key_id          = $uchiwa::params::repo_key_id,
   $repo_key_source      = $uchiwa::params::repo_key_source,
+  $install_package      = $uchiwa::params::install_package,
   $manage_services      = $uchiwa::params::manage_services,
   $manage_user          = $uchiwa::params::manage_user,
   $host                 = $uchiwa::params::host,
@@ -116,6 +122,7 @@ class uchiwa (
 
   # validate parameters here
   validate_bool($install_repo)
+  validate_bool($install_package)
   validate_bool($manage_services)
   validate_bool($manage_user)
   validate_string($package_name)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@
 #    Default: http://repos.sensuapp.org/apt/pubkey.gpg
 #    GPG key for the repo we're installing
 #
-#  [*install_package*]
+#  [*manage_package*]
 #    Boolean
 #    Default: true
 #    Should we install the package from the repo?
@@ -109,7 +109,7 @@ class uchiwa (
   $repo_source          = $uchiwa::params::repo_source,
   $repo_key_id          = $uchiwa::params::repo_key_id,
   $repo_key_source      = $uchiwa::params::repo_key_source,
-  $install_package      = $uchiwa::params::install_package,
+  $manage_package       = $uchiwa::params::manage_package,
   $manage_services      = $uchiwa::params::manage_services,
   $manage_user          = $uchiwa::params::manage_user,
   $host                 = $uchiwa::params::host,
@@ -122,7 +122,7 @@ class uchiwa (
 
   # validate parameters here
   validate_bool($install_repo)
-  validate_bool($install_package)
+  validate_bool($manage_package)
   validate_bool($manage_services)
   validate_bool($manage_user)
   validate_string($package_name)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,7 +38,7 @@ class uchiwa::install {
     }
   }
 
-  if ($uchiwa::install_package) {
+  if ($uchiwa::manage_package) {
     package { $uchiwa::package_name:
       ensure  => $uchiwa::version,
       require => $repo_require,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,10 +38,12 @@ class uchiwa::install {
     }
   }
 
-  package { $uchiwa::package_name:
-    ensure  => $uchiwa::version,
-    require => $repo_require,
-    notify  => Service['uchiwa'],
+  if ($uchiwa::install_package) {
+    package { $uchiwa::package_name:
+      ensure  => $uchiwa::version,
+      require => $repo_require,
+      notify  => Service['uchiwa'],
+    }
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class uchiwa::params {
   $repo_key_id     = '8911D8FF37778F24B4E726A218609E3D7580C77F'
   $repo_key_source = 'http://repos.sensuapp.org/apt/pubkey.gpg'
   $manage_services = true
+  $install_package = true
   $manage_user     = true
 
   $sensu_api_endpoints  = [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class uchiwa::params {
   $repo_key_id     = '8911D8FF37778F24B4E726A218609E3D7580C77F'
   $repo_key_source = 'http://repos.sensuapp.org/apt/pubkey.gpg'
   $manage_services = true
-  $install_package = true
+  $manage_package  = true
   $manage_user     = true
 
   $sensu_api_endpoints  = [


### PR DESCRIPTION
This allows installing versions not yet
in the sensuapp repo manually.

For example:

      # Download the latest uchiwa
      wget::fetch { "http://dl.bintray.com/palourde/uchiwa/uchiwa_0.12.1-1_amd64.deb":
        destination => "/root/uchiwa_0.12.1-1_amd64.deb",
        timeout     => 0,
        verbose     => false,
      } ->
    
      # Install the latest and greatest (this needs to be kept up to date)
      package { "uchiwa":
        ensure => latest,
        provider => dpkg,
        source => "/root/uchiwa_0.12.1-1_amd64.deb"
      } ->
    
      class { 'uchiwa':
        install_repo        => false,
        install_package     => false,
        manage_services     => true,
        sensu_api_endpoints => [
          {
            ssl  => false,
            host => '127.0.0.1',
            port => 4567,
            user => 'apiadmin',
            pass => $api_pass,
          }
        ]

This is useful as the sensu apt repository often falls way out of date, and this allows sysadmins to ensure they can get the latest version pretty easily without running my own apt repository.