### PR TITLE
Introducing users param in puppet-uchiwa

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,11 +99,19 @@
 #    Array of hashes
 #    An array of user credentials to access the uchiwa dashboard. If set, it takes
 #    precendence over 'user' and 'pass'.
-#    Example: [{
-#                username  => 'user1',
-#                password  => 'pass1',
-#                readonly  => false
-#             }]
+#    Example: 
+#    ```   
+#    [{
+#       'username' => 'user1',
+#       'password' => 'pass1',
+#       'readonly' => false
+#     },
+#     {
+#       'username' => 'user2',
+#       'password' => 'pass2',
+#       'readonly' => true
+#     }]
+#     ```
 #
 class uchiwa (
   $package_name         = $uchiwa::params::package_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,6 +95,16 @@
 #             }]
 #     An array of API endpoints to connect uchiwa to one or multiple sensu servers.
 #
+#  [*users*]
+#    Array of hashes
+#    An array of user credentials to access the uchiwa dashboard. If set, it takes
+#    precendence over 'user' and 'pass'.
+#    Example: [{
+#                username  => 'user1',
+#                password  => 'pass1',
+#                readonly  => false
+#             }]
+#
 class uchiwa (
   $package_name         = $uchiwa::params::package_name,
   $service_name         = $uchiwa::params::service_name,
@@ -112,6 +122,7 @@ class uchiwa (
   $pass                 = $uchiwa::params::pass,
   $refresh              = $uchiwa::params::refresh,
   $sensu_api_endpoints  = $uchiwa::params::sensu_api_endpoints,
+  $users                = $uchiwa::params::users
 ) inherits uchiwa::params {
 
   # validate parameters here
@@ -131,6 +142,7 @@ class uchiwa (
   validate_string($pass)
   validate_integer($refresh)
   validate_array($sensu_api_endpoints)
+  validate_array($users)
 
   anchor { 'uchiwa::begin': } ->
   class { 'uchiwa::install': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,4 +45,5 @@ class uchiwa::params {
   $user            =     ''
   $pass            =     ''
   $refresh         =     '5'
+  $users           =     []
 }

--- a/spec/classes/uchiwa_spec.rb
+++ b/spec/classes/uchiwa_spec.rb
@@ -152,4 +152,12 @@ describe 'uchiwa' do
     }
   end
 
+  context 'with multiple users' do
+    let(:params) {{ :users => [ { 'username' => 'user1', 'password' => 'pass1', 'readonly' => true } ] }}
+    it {
+      should contain_file('/etc/sensu/uchiwa.json') \
+        .with_content(/"username": "user1",\n        "password": "pass1",\n        "role": {\n          "readonly": true\n        }\n      }/)
+    }
+  end
+
 end

--- a/templates/etc/sensu/uchiwa.json.erb
+++ b/templates/etc/sensu/uchiwa.json.erb
@@ -20,6 +20,19 @@
     "port": <%= @port %>,
     "user": "<%= @user %>",
     "pass": "<%= @pass %>",
-    "refresh": <%= @refresh %>
+    "refresh": <%= @refresh %><%= ',' if @users.size > 0 %>
+    <%- if @users.size > 0 -%>
+    "users": [
+    <%- @users.each_with_index do |user, i| -%>
+      {
+        "username": "<%= user['username'] %>",
+        "password": "<%= user['password'] %>",
+        "role": {
+          "readonly": <%= user['readonly'] %>
+        }
+      }<%= ',' if i < (@users.size - 1) %>
+    <%- end -%>
+    ]
+  <%- end -%>
   }
 }


### PR DESCRIPTION
This PR adds support for the new `users` feature, introduced in uchiwa 0.10.0. This allows users to specify an array of credentials to access the uchiwa dashboard, rather than sharing the same set of keys.

This PR also fixes #46 