### PR TITLE
Introduce auth parameter support in puppet-uchiwa

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,18 @@
 #     }]
 #     ```
 #
+#  [*auth*]
+#    Hash
+#    A hash containing the static public and private key paths for generating and
+#    validating JSON Web Token (JWT) signatures.
+#    Example:
+#    ```
+#    {
+#      'publickey'  => '/path/to/uchiwa.rsa.pub',
+#      'privatekey' => '/path/to/uchiwa.rsa'
+#    }
+#    ```
+#
 class uchiwa (
   $package_name         = $uchiwa::params::package_name,
   $service_name         = $uchiwa::params::service_name,
@@ -130,7 +142,8 @@ class uchiwa (
   $pass                 = $uchiwa::params::pass,
   $refresh              = $uchiwa::params::refresh,
   $sensu_api_endpoints  = $uchiwa::params::sensu_api_endpoints,
-  $users                = $uchiwa::params::users
+  $users                = $uchiwa::params::users,
+  $auth                 = $uchiwa::params::auth
 ) inherits uchiwa::params {
 
   # validate parameters here
@@ -151,6 +164,7 @@ class uchiwa (
   validate_integer($refresh)
   validate_array($sensu_api_endpoints)
   validate_array($users)
+  validate_hash($auth)
 
   anchor { 'uchiwa::begin': } ->
   class { 'uchiwa::install': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,4 +46,5 @@ class uchiwa::params {
   $pass            =     ''
   $refresh         =     '5'
   $users           =     []
+  $auth            =     {}
 }

--- a/spec/classes/uchiwa_spec.rb
+++ b/spec/classes/uchiwa_spec.rb
@@ -160,4 +160,12 @@ describe 'uchiwa' do
     }
   end
 
+  context 'with static JWT RSA keys' do
+    let(:params) {{ :auth => { 'publickey' => '/etc/sensu/uchiwa.rsa.pub', 'privatekey' => '/etc/sensu/uchiwa.rsa' } }}
+    it {
+      should contain_file('/etc/sensu/uchiwa.json') \
+      .with_content(/"auth": {\n      "publickey": "\/etc\/sensu\/uchiwa.rsa.pub",\n      "privatekey": "\/etc\/sensu\/uchiwa.rsa"\n    }/)
+    }
+  end
+
 end

--- a/templates/etc/sensu/uchiwa.json.erb
+++ b/templates/etc/sensu/uchiwa.json.erb
@@ -20,7 +20,7 @@
     "port": <%= @port %>,
     "user": "<%= @user %>",
     "pass": "<%= @pass %>",
-    "refresh": <%= @refresh %><%= ',' if @users.size > 0 %>
+    "refresh": <%= @refresh %><%= ',' if @users.size > 0 or @auth.size == 2 %>
     <%- if @users.size > 0 -%>
     "users": [
     <%- @users.each_with_index do |user, i| -%>
@@ -32,7 +32,13 @@
         }
       }<%= ',' if i < (@users.size - 1) %>
     <%- end -%>
-    ]
+    ]<%= ',' if @auth.size == 2 %>
+  <%- end -%>
+  <%- if @auth.size == 2 -%>
+    "auth": {
+      "publickey": "<%= @auth['publickey']  %>",
+      "privatekey": "<%= @auth['privatekey']  %>"
+    }
   <%- end -%>
   }
 }


### PR DESCRIPTION
The auth parameter has been introduced in uchiwa 0.13.0 in order to allow the user to specify a static RSA keypair for JWT signature validation.

This PR introduces support for this param in the puppet-uchiwa module.