### PR TITLE
users add - json missing  comma

### DIFF
--- a/templates/etc/sensu/uchiwa.json.erb
+++ b/templates/etc/sensu/uchiwa.json.erb
@@ -41,7 +41,7 @@
         }
       }<%= ',' if i < (@users.size - 1) %>
     <%- end -%>
-    ]<%= ',' if @auth.size == 2 %>
+    ]<%= ',' if @users.size %>
   <%- end -%>
   <%- if @auth.size == 2 -%>
     "auth": {


### PR DESCRIPTION
Hi,

Adding users in manifest:
```
  users => [
    {
      'username' => 'user1,
      'password' => 'pass1',
      'readonly' => false,
    },
    {
      'username' => 'user2',
      'password' => 'pass2',
      'readonly' => true,
    }
  ],
```
in logs Uchiwa fails to start with not very intuitive error:
```
{"timestamp":"2016-06-01T12:23:10.461145438Z","level":"fatal","message":"Error decoding file /etc/sensu/uchiwa.json: invalid character '\"' after object key:value pair"}
```

configuration  `/etc/sensu/uchiwa.json` misses comma between `users` and  `ssl` sections.

    "users": [
      {
        "username": "user1",
        "password": "pass1",
        "role": {
          "readonly": false
        }
      },
      {
        "username": "user2",
        "password": "pass2",
        "role": {
          "readonly": true
        }
      }
    ]    "no comma here"
    "ssl": {
      "certfile": "/etc/sensu/ssl/uchiwa.pem",
      "keyfile": "/etc/sensu/ssl/uchiwa.key"
    }

Karolis