### PR TITLE
Correct default entry for sensu_api_endpoints

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,7 @@
 #    Default: [{
 #               name     => 'sensu',
 #               ssl      => false,
-#               hostname => '127.0.0.1',
+#               host     => '127.0.0.1',
 #               port     => 4567,
 #               user     => 'sensu',
 #               pass     => 'sensu',


### PR DESCRIPTION
Default sensu_api_endpoints variable should be `host` not `hostname`. This just corrects the Parameters listing in init.pp