### PR TITLE
Update repo URI for YUM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ script:
   - "rake syntax"
   - "rake spec SPEC_OPTS='--format documentation'"
 env:
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.5.0"
   - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.6.0"
@@ -35,5 +32,3 @@ matrix:
       env: PUPPET_VERSION="~> 3.2.0"
     - rvm: 2.1.0
       env: PUPPET_VERSION="~> 3.3.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,7 @@
 source "https://rubygems.org"
 
 group :development do
-  gem "beaker", "> 2.0.0"
-  gem "beaker-rspec", ">= 5.1.0"
-  gem "beaker-puppet_install_helper"
-  gem "pry"
   gem "puppet-blacksmith"
-  gem "serverspec"
-  gem "vagrant-wrapper"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,229 +2,23 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.2.8)
-    addressable (2.4.0)
-    aws-sdk (1.66.0)
-      aws-sdk-v1 (= 1.66.0)
-    aws-sdk-v1 (1.66.0)
-      json (~> 1.4)
-      nokogiri (>= 1.4.4)
-    beaker (2.47.1)
-      aws-sdk (~> 1.57)
-      beaker-answers (~> 0.0)
-      beaker-hiera (~> 0.0)
-      beaker-hostgenerator
-      beaker-pe (~> 0.0)
-      docker-api
-      fission (~> 0.4)
-      fog (~> 1.25, < 1.35.0)
-      fog-google (~> 0.0.9)
-      google-api-client (~> 0.8, < 0.9.5)
-      hocon (~> 1.0)
-      in-parallel (~> 0.1)
-      inifile (~> 2.0)
-      json (~> 1.8)
-      mime-types (~> 2.99)
-      minitest (~> 5.4)
-      net-scp (~> 1.2)
-      net-ssh (~> 2.9)
-      open_uri_redirections (~> 0.2.1)
-      rbvmomi (~> 1.8)
-      rsync (~> 1.0.9)
-      stringify-hash (~> 0.0)
-      unf (~> 0.1)
-    beaker-answers (0.8.0)
-      hocon (~> 1.0)
-      require_all (~> 1.3.2)
-      stringify-hash (~> 0.0.0)
-    beaker-hiera (0.1.1)
-      stringify-hash (~> 0.0.0)
-    beaker-hostgenerator (0.7.2)
-      deep_merge (~> 1.0)
-      stringify-hash (~> 0.0.0)
-    beaker-pe (0.7.0)
-      stringify-hash (~> 0.0.0)
-    beaker-puppet_install_helper (0.4.4)
-      beaker (~> 2.0)
-    beaker-rspec (5.6.0)
-      beaker (~> 2.0)
-      rspec
-      serverspec (~> 2)
-      specinfra (~> 2)
-    builder (3.2.2)
-    coderay (1.1.1)
-    deep_merge (1.0.1)
-    diff-lcs (1.2.5)
-    docker-api (1.29.1)
-      excon (>= 0.38.0)
-      json
-    domain_name (0.5.20160615)
+    diff-lcs (1.3)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    excon (0.51.0)
     facter (2.4.6)
       CFPropertyList (~> 2.2.6)
-    faraday (0.9.2)
-      multipart-post (>= 1.2, < 3)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (1.34.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-core (~> 1.32)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (>= 0.0.2)
-      fog-json
-      fog-local
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (0.10.0)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-brightbox (0.11.0)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto (~> 0.0.2)
-    fog-core (1.42.0)
-      builder
-      excon (~> 0.49)
-      formatador (~> 0.2)
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (0.0.9)
-      fog-core
-      fog-json
-      fog-xml
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
-      multi_json (~> 1.10)
-    fog-local (0.3.0)
-      fog-core (~> 1.27)
-    fog-powerdns (0.1.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-    fog-profitbricks (0.0.5)
-      fog-core
-      fog-xml
-      nokogiri
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.3)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-xml (0.1.2)
-      fog-core
-      nokogiri (~> 1.5, >= 1.5.11)
-    formatador (0.2.5)
-    google-api-client (0.9.4)
-      addressable (~> 2.3)
-      googleauth (~> 0.5)
-      httpclient (~> 2.7)
-      hurley (~> 0.1)
-      memoist (~> 0.11)
-      mime-types (>= 1.6)
-      representable (~> 2.3.0)
-      retriable (~> 2.0)
-      thor (~> 0.19)
-    googleauth (0.5.1)
-      faraday (~> 0.9)
-      jwt (~> 1.4)
-      logging (~> 2.0)
-      memoist (~> 0.12)
-      multi_json (~> 1.11)
-      os (~> 0.9)
-      signet (~> 0.7)
     hiera (1.3.4)
       json_pure
     hiera-puppet-helper (1.0.1)
-    hocon (1.1.2)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
-    httpclient (2.8.0)
-    hurley (0.2)
-    in-parallel (0.1.12)
-    inflecto (0.0.2)
-    inifile (2.0.2)
-    ipaddress (0.8.3)
-    json (1.8.3)
-    json_pure (1.8.3)
-    jwt (1.5.4)
-    little-plugger (1.1.4)
-    logging (2.1.0)
-      little-plugger (~> 1.1)
-      multi_json (~> 1.10)
-    memoist (0.14.0)
+    json (1.8.6)
+    json_pure (1.8.6)
     metaclass (0.0.4)
-    method_source (0.8.2)
-    mime-types (2.99.2)
-    mini_portile2 (2.1.0)
-    minitest (5.9.0)
-    mocha (1.1.0)
+    mime-types (2.99.3)
+    mocha (1.2.1)
       metaclass (~> 0.0.1)
-    multi_json (1.12.1)
-    multipart-post (2.0.0)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-ssh (2.9.4)
-    net-telnet (0.1.1)
     netrc (0.11.0)
-    nokogiri (1.6.8)
-      mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
-    open_uri_redirections (0.2.1)
-    os (0.9.6)
-    pkg-config (1.1.7)
-    pry (0.10.4)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
     puppet (3.7.5)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
@@ -232,28 +26,19 @@ GEM
     puppet-blacksmith (3.4.0)
       puppet (>= 2.7.16)
       rest-client (~> 1.8.0)
-    puppet-lint (2.0.0)
-    puppet-syntax (2.1.0)
+    puppet-lint (2.2.1)
+    puppet-syntax (2.4.1)
       rake
-    puppetlabs_spec_helper (1.1.1)
-      mocha
-      puppet-lint
-      puppet-syntax
-      rake
-      rspec-puppet
+    puppetlabs_spec_helper (2.2.0)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
     rake (10.5.0)
-    rbvmomi (1.8.2)
-      builder
-      nokogiri (>= 1.4.1)
-      trollop
-    representable (2.3.0)
-      uber (~> 0.0.7)
-    require_all (1.3.3)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    retriable (2.1.0)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -263,53 +48,23 @@ GEM
     rspec-expectations (3.1.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.1.0)
-    rspec-its (1.2.0)
-      rspec-core (>= 3.0.0)
-      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
-    rspec-puppet (2.4.0)
+    rspec-puppet (2.6.4)
       rspec
     rspec-support (3.1.2)
-    rsync (1.0.9)
-    serverspec (2.36.0)
-      multi_json
-      rspec (~> 3.0)
-      rspec-its
-      specinfra (~> 2.53)
-    sfl (2.2)
-    signet (0.7.3)
-      addressable (~> 2.3)
-      faraday (~> 0.9)
-      jwt (~> 1.5)
-      multi_json (~> 1.10)
-    slop (3.6.0)
-    specinfra (2.60.2)
-      net-scp
-      net-ssh (>= 2.7, < 4.0)
-      net-telnet
-      sfl
-    stringify-hash (0.0.2)
-    thor (0.19.1)
-    trollop (2.1.2)
-    uber (0.0.15)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
-    vagrant-wrapper (2.0.3)
+    unf_ext (0.0.7.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  beaker (> 2.0.0)
-  beaker-puppet_install_helper
-  beaker-rspec (>= 5.1.0)
   hiera
   hiera-puppet-helper
   json (~> 1.8.3)
   json_pure (~> 1.8.3)
-  pry
   puppet (~> 3.7.0)
   puppet-blacksmith
   puppet-lint
@@ -319,8 +74,6 @@ DEPENDENCIES
   rspec (< 3.2.0)
   rspec-core (= 3.1.7)
   rspec-puppet (~> 2.1)
-  serverspec
-  vagrant-wrapper
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -180,9 +180,9 @@ class uchiwa (
   validate_hash($ssl)
   validate_hash($usersoptions)
 
-  anchor { 'uchiwa::begin': } ->
-  class { 'uchiwa::install': } ->
-  class { 'uchiwa::config': } ~>
-  class { 'uchiwa::service': } ->
-  anchor { 'uchiwa::end': }
+  anchor { 'uchiwa::begin': }
+  -> class { 'uchiwa::install': }
+  -> class { 'uchiwa::config': }
+  ~> class { 'uchiwa::service': }
+  -> anchor { 'uchiwa::end': }
 }

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -13,8 +13,8 @@ class uchiwa::repo::yum {
       $url = $uchiwa::repo_source
     } else {
       $url = $uchiwa::repo ? {
-        'unstable'  => "http://repos.sensuapp.org/yum-unstable/el/${::operatingsystemmajrelease}/\$basearch/",
-        default     => "http://repos.sensuapp.org/yum/el/${::operatingsystemmajrelease}/\$basearch/"
+        'unstable'  => "https://repositories.sensuapp.org/yum-unstable/${::operatingsystemmajrelease}/\$basearch/",
+        default     => "https://repositories.sensuapp.org/yum/${::operatingsystemmajrelease}/\$basearch/"
       }
     }
 

--- a/spec/classes/uchiwa_spec.rb
+++ b/spec/classes/uchiwa_spec.rb
@@ -113,7 +113,7 @@ describe 'uchiwa' do
         context 'default' do
           it { should contain_yumrepo('uchiwa').with(
             :enabled   => 1,
-            :baseurl   => 'http://repos.sensuapp.org/yum/el/6/$basearch/',
+            :baseurl   => 'https://repositories.sensuapp.org/yum/6/$basearch/',
             :gpgcheck  => 0,
             :before    => 'Package[uchiwa]'
           ) }
@@ -121,7 +121,7 @@ describe 'uchiwa' do
 
         context 'unstable repo' do
           let(:params) { { :repo => 'unstable' } }
-          it { should contain_yumrepo('uchiwa').with(:baseurl => 'http://repos.sensuapp.org/yum-unstable/el/6/$basearch/' )}
+          it { should contain_yumrepo('uchiwa').with(:baseurl => 'https://repositories.sensuapp.org/yum-unstable/6/$basearch/' )}
         end
 
         context 'override repo url' do


### PR DESCRIPTION
Old URI is not valid anymore. Updating to `repositories.sensuapp.org`. Rspec test also updated with new URI.