### PR TITLE
Module Requirements Update, Issue #85

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,11 +5,7 @@
 #
 class uchiwa::params {
   case $::osfamily {
-    'Debian': {
-      $package_name = 'uchiwa'
-      $service_name = 'uchiwa'
-    }
-    'RedHat', 'Amazon': {
+    'Debian', 'RedHat', 'Amazon': {
       $package_name = 'uchiwa'
       $service_name = 'uchiwa'
     }

--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,9 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "10.04",
-        "12.04"
+        "12.04",
+        "14.04.5",
+        "16.04.4"
       ]
     }
   ],
@@ -67,7 +69,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.0.0 <3.0.0"
+      "version_requirement": ">=2.0.0 <5.0.1"
     },
     {
       "name": "puppetlabs/stdlib"


### PR DESCRIPTION
Issue link: https://github.com/Yelp/puppet-uchiwa/issues/85

I took a look at the module to make sure there wasn't anything that wouldn't function with the latest version of puppetlabs-apt (5.0.1), and it seems pretty straightforward, nothing that shouldn't work.

I have the module running cleanly on Ubuntu 14.04.5 and 16.04.4 so I added those to the supported OS list as well. I see no reason why this wouldn't run on Debian 8 at the least, and probably 9 as well, but I didn't have any VMs handy to try installing on.

I noticed a bit of redundant logic in the params class and cleaned that up also. 

