### PR TITLE
Bugfix: Apt update before the installation of the package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@
 #
 #  [*repo_key_source*]
 #    String
-#    Default: https://repositories.sensuapp.org/apt/pubkey.gpg
+#    Default: https://eol-repositories.sensuapp.org/apt/pubkey.gpg
 #    GPG key for the repo we're installing
 #
 #  [*manage_package*]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class uchiwa::params {
   $repo_release    = undef
   $repo_source     = undef
   $repo_key_id     = 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB'
-  $repo_key_source = 'https://repositories.sensuapp.org/apt/pubkey.gpg'
+  $repo_key_source = 'https://eol-repositories.sensuapp.org/apt/pubkey.gpg'
   $manage_services = true
   $manage_package  = true
   $manage_user     = true

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -19,7 +19,7 @@ class uchiwa::repo::apt {
       if $uchiwa::repo_source {
         $url = $uchiwa::repo_source
       } else {
-        $url = 'https://repositories.sensuapp.org/apt'
+        $url = 'https://eol-repositories.sensuapp.org/apt'
       }
 
       # ignoring the puppet-lint plugin because of a bug that warns on the next

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -30,6 +30,8 @@ class uchiwa::repo::apt {
         $release = $::uchiwa::repo_release
       }
 
+      include apt
+
       apt::source { 'uchiwa':
         ensure   => $ensure,
         before   => Package['uchiwa'],
@@ -44,6 +46,9 @@ class uchiwa::repo::apt {
         location => $url,
         release  => $release,
         repos    => $uchiwa::repo,
+      }
+      if $uchiwa::manage_package {
+        Class['apt::update'] -> Package[$uchiwa::package_name]
       }
 
     } else {

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -13,8 +13,8 @@ class uchiwa::repo::yum {
       $url = $uchiwa::repo_source
     } else {
       $url = $uchiwa::repo ? {
-        'unstable'  => "https://repositories.sensuapp.org/yum-unstable/${::operatingsystemmajrelease}/\$basearch/",
-        default     => "https://repositories.sensuapp.org/yum/${::operatingsystemmajrelease}/\$basearch/"
+        'unstable'  => "https://eol-repositories.sensuapp.org/yum-unstable/${::operatingsystemmajrelease}/\$basearch/",
+        default     => "https://eol-repositories.sensuapp.org/yum/${::operatingsystemmajrelease}/\$basearch/"
       }
     }
 

--- a/spec/classes/uchiwa_spec.rb
+++ b/spec/classes/uchiwa_spec.rb
@@ -54,11 +54,11 @@ describe 'uchiwa' do
           context 'default' do
             it { should contain_apt__source('uchiwa').with(
               :ensure   => 'present',
-              :location => 'https://repositories.sensuapp.org/apt',
+              :location => 'https://eol-repositories.sensuapp.org/apt',
               :release  => 'jessie',
               :repos    => 'main',
               :include  => { 'src' => false, 'deb' => true },
-              :key      => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source' => 'https://repositories.sensuapp.org/apt/pubkey.gpg' },
+              :key      => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source' => 'https://eol-repositories.sensuapp.org/apt/pubkey.gpg' },
               :before   => 'Package[uchiwa]'
             ) }
           end
@@ -102,7 +102,7 @@ describe 'uchiwa' do
 
             it { should_not contain_apt__key('uchiwa').with(
               :key         => '7580C77F',
-              :key_source  => 'https://repositories.sensuapp.org/apt/pubkey.gpg'
+              :key_source  => 'https://eol-repositories.sensuapp.org/apt/pubkey.gpg'
             ) }
 
             it { should contain_package('uchiwa').with(
@@ -122,7 +122,7 @@ describe 'uchiwa' do
         context 'default' do
           it { should contain_yumrepo('uchiwa').with(
             :enabled   => 1,
-            :baseurl   => 'https://repositories.sensuapp.org/yum/6/$basearch/',
+            :baseurl   => 'https://eol-repositories.sensuapp.org/yum/6/$basearch/',
             :gpgcheck  => 0,
             :before    => 'Package[uchiwa]'
           ) }
@@ -130,7 +130,7 @@ describe 'uchiwa' do
 
         context 'unstable repo' do
           let(:params) { { :repo => 'unstable' } }
-          it { should contain_yumrepo('uchiwa').with(:baseurl => 'https://repositories.sensuapp.org/yum-unstable/6/$basearch/' )}
+          it { should contain_yumrepo('uchiwa').with(:baseurl => 'https://eol-repositories.sensuapp.org/yum-unstable/6/$basearch/' )}
         end
 
         context 'override repo url' do


### PR DESCRIPTION
Hi

It seems to me that there is not any dependency between Exec['apt_update'] and Package['uchiwa''].
Specifically, this is what I when Puppet tries to install `uchiwa` package before executing `apt update`.

```
Notice: /Stage[main]/Uchiwa::Install/User[uchiwa]/ensure: created
Error: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install uchiwa' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package uchiwa
Error: /Stage[main]/Uchiwa::Install/Package[uchiwa]/ensure: change from purged to latest failed: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install uchiwa' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package uchiwa
Notice: /Stage[main]/Uchiwa::Config/File[/etc/sensu/uchiwa.json]: Dependency Package[uchiwa] has failures: true
Warning: /Stage[main]/Uchiwa::Config/File[/etc/sensu/uchiwa.json]: Skipping because of failed dependencies
Notice: /Stage[main]/Apt::Update/Exec[apt_update]/returns: Ign:1 http://deb.debian.org/debian stretch InRelease
```

More details in the official documentation of puppetlabs-apt:
https://github.com/puppetlabs/puppetlabs-apt#adding-new-sources-or-ppas

> If you are adding a new source and trying to install packagesfrom the new source on the same Puppet run, your package resourceshould depend on Class[’apt::update’], as well as depending on theApt::Source resource”